### PR TITLE
Fix Event participant validation and add tests

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -107,7 +107,7 @@ class Event(models.Model):
             raise ValidationError("End time must be after start time")
         
         # Ensure all participants belong to the same eventum
-        for participant in self.individual_participants.all():
+        for participant in self.participants.all():
             if participant.eventum != self.eventum:
                 raise ValidationError(
                     f"Participant {participant.name} belongs to a different eventum"

--- a/backend/app/tests.py
+++ b/backend/app/tests.py
@@ -1,3 +1,39 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.test import TestCase
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+
+from .models import Eventum, Participant, Event
+
+
+class EventModelTest(TestCase):
+    def setUp(self):
+        self.eventum1 = Eventum.objects.create(
+            name="Eventum 1", slug="eventum-1", password_hash="hash1"
+        )
+        self.eventum2 = Eventum.objects.create(
+            name="Eventum 2", slug="eventum-2", password_hash="hash2"
+        )
+        self.participant1 = Participant.objects.create(
+            eventum=self.eventum1, name="Participant 1"
+        )
+        self.participant2 = Participant.objects.create(
+            eventum=self.eventum2, name="Participant 2"
+        )
+        self.event = Event.objects.create(
+            eventum=self.eventum1,
+            name="Sample Event",
+            start_time=timezone.now(),
+            end_time=timezone.now() + timedelta(hours=1),
+        )
+
+    def test_clean_allows_same_eventum_participants(self):
+        self.event.participants.add(self.participant1)
+        # Should not raise any validation errors
+        self.event.full_clean()
+
+    def test_clean_rejects_cross_eventum_participants(self):
+        self.event.participants.add(self.participant1, self.participant2)
+        with self.assertRaises(ValidationError):
+            self.event.full_clean()


### PR DESCRIPTION
## Summary
- fix Event model to check participants via the correct relation
- add tests for participant eventum validation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'import_export')*

------
https://chatgpt.com/codex/tasks/task_e_689d033c04fc83289c80bbea5a34380f