### PR TITLE
Avoid refetching data when switching Eventum tabs

### DIFF
--- a/frontend/src/pages/EventumPage.tsx
+++ b/frontend/src/pages/EventumPage.tsx
@@ -73,8 +73,12 @@ const EventumPage = () => {
 
           {/* Содержимое вкладок */}
           <div>
-            {activeTab === 'participants' && <ParticipantList eventumSlug={eventumSlug} />}
-            {activeTab === 'events' && <EventList eventumSlug={eventumSlug} />}
+            <div className={activeTab === 'participants' ? '' : 'hidden'}>
+              <ParticipantList eventumSlug={eventumSlug} />
+            </div>
+            <div className={activeTab === 'events' ? '' : 'hidden'}>
+              <EventList eventumSlug={eventumSlug} />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Keep participants and events components mounted and hide the inactive one so tab data is fetched only once

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3582a968c832881c3192abbd05340