### PR TITLE
Optimize queryset prefetching for event endpoints

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -49,12 +49,15 @@ class ParticipantViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
     permission_classes = [IsEventumOrganizerOrReadOnly]  # Организаторы CRUD, участники только чтение
 
 class ParticipantGroupViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
-    queryset = ParticipantGroup.objects.all()
+    queryset = ParticipantGroup.objects.all().prefetch_related('participants', 'tags')
     serializer_class = ParticipantGroupSerializer
     permission_classes = [IsEventumOrganizerOrReadOnly]  # Организаторы CRUD, участники только чтение
 
 class GroupTagViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
-    queryset = GroupTag.objects.all()
+    queryset = GroupTag.objects.all().prefetch_related(
+        'groups__participants',
+        'groups__tags',
+    )
     serializer_class = GroupTagSerializer
     permission_classes = [IsEventumOrganizerOrReadOnly]  # Организаторы CRUD, участники только чтение
 
@@ -62,7 +65,7 @@ class GroupTagViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
     def groups(self, request, eventum_slug=None, pk=None):
         """Получить все группы с данным тегом"""
         group_tag = self.get_object()
-        groups = group_tag.groups.all()
+        groups = group_tag.groups.all().prefetch_related('participants', 'tags')
         serializer = ParticipantGroupSerializer(groups, many=True)
         return Response(serializer.data)
 
@@ -94,7 +97,13 @@ class EventTagViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
     permission_classes = [IsEventumOrganizerOrReadOnly]  # Организаторы CRUD, участники только чтение
 
 class EventViewSet(EventumScopedViewSet, viewsets.ModelViewSet):
-    queryset = Event.objects.all()
+    queryset = Event.objects.all().select_related('eventum').prefetch_related(
+        'participants',
+        'groups',
+        'groups__participants',
+        'groups__tags',
+        'tags',
+    )
     serializer_class = EventSerializer
     permission_classes = [IsEventumOrganizerOrReadOnly]  # Организаторы CRUD, участники только чтение
 


### PR DESCRIPTION
## Summary
- prefetch participants and tags for participant groups and tagged group listings to eliminate N+1 queries
- eager load related participants, groups, and tags on event viewsets to reduce database round trips

## Testing
- python manage.py test *(fails: SECRET_KEY setting must not be empty)*

------
https://chatgpt.com/codex/tasks/task_e_68d69ae34e908328bc7b08d0cddd24da