### PR TITLE
feat: refresh UI with responsive design

### DIFF
--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
 import Header from "./Header";
 import {
@@ -13,6 +13,7 @@ import {
 } from "./icons";
 
 const AdminLayout = () => {
+  const location = useLocation();
   const menu = [
     { to: ".", label: "Общие", icon: IconHome, end: true },
     { to: "events", label: "Мероприятия", icon: IconCalendar },
@@ -27,7 +28,7 @@ const AdminLayout = () => {
     try {
       const saved = localStorage.getItem("adminSidebarCollapsed");
       if (saved !== null) return JSON.parse(saved);
-    } catch (_) {
+    } catch {
       // ignore
     }
     return false; // По умолчанию развернута
@@ -39,25 +40,58 @@ const AdminLayout = () => {
         "adminSidebarCollapsed",
         JSON.stringify(collapsed)
       );
-    } catch (_) {
+    } catch {
       // ignore
     }
   }, [collapsed]);
 
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [location.pathname]);
+
   const AsideToggleIcon = collapsed ? IconChevronRight : IconChevronLeft;
+
+  const handleMenuToggle = () => {
+    setIsMobileMenuOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        setCollapsed(false);
+      }
+      return next;
+    });
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Top bar across the page */}
-      <Header variant="admin" />
+      <Header
+        variant="admin"
+        onMenuToggle={handleMenuToggle}
+        isMenuOpen={isMobileMenuOpen}
+        showMenuToggle
+      />
 
       {/* Content row: sidebar + page */}
       <div className="flex flex-1 min-h-0">
+        {/* Backdrop for mobile menu */}
+        {isMobileMenuOpen && (
+          <button
+            type="button"
+            className="fixed inset-0 z-30 bg-black/40 backdrop-blur-sm lg:hidden"
+            onClick={handleMenuToggle}
+            aria-label="Закрыть меню"
+          />
+        )}
+
         {/* Sidebar */}
         <aside
           className={`${
-            collapsed ? "w-16" : "w-64"
-          } bg-white border-r border-gray-200 pt-2 pb-3 pl-0 pr-2 flex flex-col transition-all duration-200 z-40 sticky top-14 h-[calc(100vh-56px)] overflow-hidden`}
+            collapsed ? "lg:w-20" : "lg:w-64"
+          } fixed top-14 bottom-0 left-0 z-40 w-64 transform bg-white border-r border-gray-200 pt-2 pb-3 pl-0 pr-2 flex flex-col transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 lg:h-[calc(100vh-56px)] ${
+            isMobileMenuOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
           aria-label="Админ-меню"
         >
           <div className="flex-1 overflow-y-auto">
@@ -72,17 +106,15 @@ const AdminLayout = () => {
                     title={item.label}
                     aria-label={item.label}
                     className={({ isActive }) =>
-                      `flex items-center ${
-                        collapsed ? "justify-center" : "justify-start"
-                      } gap-3 pl-0 pr-2 py-2 rounded text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors border-l-2 ${
+                      `flex items-center justify-start gap-3 px-3 py-2 rounded text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors border-l-4 ${
                         isActive ? "bg-gray-100 font-medium border-blue-600" : "border-transparent"
-                      }`
+                      } ${collapsed ? "lg:justify-center lg:px-2 lg:border-l-0" : ""}`
                     }
                   >
                     <Icon className="shrink-0 text-gray-600" />
                     <span
                       className={`${
-                        collapsed ? "hidden" : "block"
+                        collapsed ? "lg:hidden" : ""
                       } text-sm whitespace-nowrap`}
                     >
                       {item.label}
@@ -101,7 +133,7 @@ const AdminLayout = () => {
               aria-expanded={!collapsed}
             >
               <AsideToggleIcon />
-              <span className={collapsed ? "hidden" : "text-sm"}>
+              <span className={`text-sm ${collapsed ? 'hidden lg:inline' : ''}`}>
                 {collapsed ? "Открыть" : "Свернуть"}
               </span>
             </button>
@@ -109,7 +141,7 @@ const AdminLayout = () => {
         </aside>
 
         {/* Page content */}
-        <main className="flex-1 min-w-0 p-4 sm:p-6">
+        <main className="flex-1 min-w-0 p-4 sm:p-6 lg:p-8">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,15 +1,25 @@
 import { Link } from "react-router-dom";
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { IconBars3, IconUser, IconLogout } from "./icons";
+import { IconBars3, IconUser, IconLogout, IconX } from "./icons";
 
 interface HeaderProps {
   variant?: 'default' | 'admin';
   className?: string;
   showUserInfo?: boolean;
+  onMenuToggle?: () => void;
+  isMenuOpen?: boolean;
+  showMenuToggle?: boolean;
 }
 
-const Header = ({ variant = 'default', className = '', showUserInfo = true }: HeaderProps) => {
+const Header = ({
+  variant = 'default',
+  className = '',
+  showUserInfo = true,
+  onMenuToggle,
+  isMenuOpen = false,
+  showMenuToggle = false,
+}: HeaderProps) => {
   const { user, logout } = useAuth();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -90,16 +100,29 @@ const Header = ({ variant = 'default', className = '', showUserInfo = true }: He
   };
 
   if (isAdmin) {
+    const shouldRenderToggle = showMenuToggle && typeof onMenuToggle === 'function';
     return (
       <header className={`h-14 bg-white border-b border-gray-200 sticky top-0 z-40 ${className}`}>
-        <div className="h-full px-6 flex items-center justify-between">
-          <Link
-            to="/"
-            className="text-xl font-medium text-gray-900 hover:text-gray-700"
-          >
-            Eventum
-          </Link>
-          
+        <div className="h-full px-4 sm:px-6 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            {shouldRenderToggle && (
+              <button
+                type="button"
+                onClick={onMenuToggle}
+                className="inline-flex items-center justify-center rounded-md border border-gray-200 bg-white p-2 text-gray-600 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 lg:hidden"
+                aria-label={isMenuOpen ? 'Скрыть меню' : 'Открыть меню'}
+              >
+                {isMenuOpen ? <IconX size={18} /> : <IconBars3 size={18} />}
+              </button>
+            )}
+            <Link
+              to="/"
+              className="text-lg font-semibold text-gray-900 hover:text-gray-700 sm:text-xl"
+            >
+              Eventum
+            </Link>
+          </div>
+
           <UserMenu />
         </div>
       </header>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,9 +3,9 @@ import Header from "./Header";
 
 const Layout = () => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
-      <main className="max-w-6xl mx-auto px-6 py-8">
+      <main className="flex-1 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/VKAuth.tsx
+++ b/frontend/src/components/VKAuth.tsx
@@ -119,16 +119,18 @@ const VKAuth: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50">
-      <div className="max-w-md w-full bg-white rounded-lg shadow-md p-8">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Eventum</h1>
-          <p className="text-gray-600">Войдите через VK для продолжения</p>
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 px-4 py-8 sm:py-12">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-6 sm:p-8">
+        <div className="text-center mb-8 space-y-2">
+          <h1 className="text-3xl font-bold text-gray-900">Eventum</h1>
+          <p className="text-gray-600 text-sm sm:text-base">
+            Войдите через VK для продолжения
+          </p>
         </div>
 
         {error && (
-          <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
-            <p className="text-red-600 text-sm">{error}</p>
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+            <p className="text-sm text-red-600">{error}</p>
           </div>
         )}
 

--- a/frontend/src/components/event/EventList.tsx
+++ b/frontend/src/components/event/EventList.tsx
@@ -42,22 +42,34 @@ const EventList = ({ eventumSlug }: EventListProps) => {
   if (error) return <p className="text-center text-red-400">{error}</p>;
 
   return (
-    <div className="mt-6 space-y-4">
+    <div className="space-y-4">
       {events.length > 0 ? (
         events.map((event) => (
-          <div key={event.id} className="p-4 border border-gray-200 rounded-lg">
-            <h3 className="text-lg font-semibold text-gray-800">
-              {event.name}
-            </h3>
-            <p className="text-sm text-gray-600 mt-1">{event.description}</p>
-            <div className="text-sm text-gray-500 mt-2">
-              <span>{formatDateTime(event.start_time)}</span> -{" "}
-              <span>{formatDateTime(event.end_time)}</span>
+          <article
+            key={event.id}
+            className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md sm:p-6"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-gray-900">{event.name}</h3>
+                {event.description && (
+                  <p className="text-sm leading-6 text-gray-600">{event.description}</p>
+                )}
+              </div>
+              <dl className="rounded-lg bg-blue-50 px-3 py-2 text-xs text-blue-800 sm:px-4">
+                <dt className="font-medium uppercase tracking-wide">Период</dt>
+                <dd className="mt-1 space-y-1 text-blue-900">
+                  <p>{formatDateTime(event.start_time)}</p>
+                  <p>{formatDateTime(event.end_time)}</p>
+                </dd>
+              </dl>
             </div>
-          </div>
+          </article>
         ))
       ) : (
-        <p className="text-gray-500">Мероприятия еще не добавлены.</p>
+        <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
+          Мероприятия еще не добавлены
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/eventTag/EventTagList.tsx
+++ b/frontend/src/components/eventTag/EventTagList.tsx
@@ -107,11 +107,11 @@ const EventTagList: React.FC<EventTagListProps> = ({ eventumSlug }) => {
         </div>
       )}
 
-      <div className="flex justify-between items-center">
-        <h3 className="text-lg font-medium">Теги мероприятий</h3>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">Теги мероприятий</h3>
         <button
           onClick={() => setShowCreateForm(true)}
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium"
+          className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
           Добавить тег
         </button>
@@ -119,27 +119,27 @@ const EventTagList: React.FC<EventTagListProps> = ({ eventumSlug }) => {
 
       {/* Форма создания */}
       {showCreateForm && (
-        <div className="bg-gray-50 p-4 rounded-lg">
-          <h4 className="font-medium mb-3">Создать новый тег</h4>
-          <form onSubmit={handleCreate} className="flex gap-2">
+        <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+          <h4 className="text-base font-semibold text-gray-900">Создать новый тег</h4>
+          <form onSubmit={handleCreate} className="mt-4 flex flex-col gap-3 sm:flex-row">
             <input
               type="text"
               value={formData.name}
               onChange={(e) => setFormData({ name: e.target.value })}
               placeholder="Название тега"
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               required
             />
             <button
               type="submit"
-              className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md text-sm"
+              className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
             >
               Создать
             </button>
             <button
               type="button"
               onClick={cancelCreate}
-              className="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm"
+              className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
             >
               Отмена
             </button>
@@ -155,48 +155,48 @@ const EventTagList: React.FC<EventTagListProps> = ({ eventumSlug }) => {
           </p>
         ) : (
           tags.map((tag) => (
-            <div key={tag.id} className="bg-white border border-gray-200 rounded-lg p-4">
+            <div key={tag.id} className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
               {editingTag?.id === tag.id ? (
                 /* Форма редактирования */
-                <form onSubmit={handleUpdate} className="flex gap-2">
+                <form onSubmit={handleUpdate} className="flex flex-col gap-3 sm:flex-row">
                   <input
                     type="text"
                     value={formData.name}
                     onChange={(e) => setFormData({ name: e.target.value })}
-                    className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                     required
                   />
                   <button
                     type="submit"
-                    className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md text-sm"
+                    className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
                   >
                     Сохранить
                   </button>
                   <button
                     type="button"
                     onClick={cancelEdit}
-                    className="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm"
+                    className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
                   >
                     Отмена
                   </button>
                 </form>
               ) : (
                 /* Отображение тега */
-                <div className="flex justify-between items-center">
-                  <div>
-                    <h4 className="font-medium text-gray-900">{tag.name}</h4>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="space-y-1">
+                    <h4 className="text-base font-semibold text-gray-900">{tag.name}</h4>
                     <p className="text-sm text-gray-500">slug: {tag.slug}</p>
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-col gap-2 sm:flex-row">
                     <button
                       onClick={() => startEdit(tag)}
-                      className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                      className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                     >
                       Редактировать
                     </button>
                     <button
                       onClick={() => handleDelete(tag.id)}
-                      className="text-red-600 hover:text-red-800 text-sm font-medium"
+                      className="inline-flex items-center justify-center rounded-lg border border-red-200 px-4 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
                     >
                       Удалить
                     </button>

--- a/frontend/src/components/groupTag/GroupTagList.tsx
+++ b/frontend/src/components/groupTag/GroupTagList.tsx
@@ -237,11 +237,11 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
         </div>
       )}
 
-      <div className="flex justify-between items-center">
-        <h3 className="text-lg font-medium">Теги групп</h3>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">Теги групп</h3>
         <button
           onClick={() => setShowCreateForm(true)}
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium"
+          className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
           Добавить тег
         </button>
@@ -249,27 +249,27 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
 
       {/* Форма создания */}
       {showCreateForm && (
-        <div className="bg-gray-50 p-4 rounded-lg">
-          <h4 className="font-medium mb-3">Создать новый тег</h4>
-          <form onSubmit={handleCreate} className="flex gap-2">
+        <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+          <h4 className="text-base font-semibold text-gray-900">Создать новый тег</h4>
+          <form onSubmit={handleCreate} className="mt-4 flex flex-col gap-3 sm:flex-row">
             <input
               type="text"
               value={formData.name}
               onChange={(e) => setFormData({ name: e.target.value })}
               placeholder="Название тега"
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               required
             />
             <button
               type="submit"
-              className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md text-sm"
+              className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
             >
               Создать
             </button>
             <button
               type="button"
               onClick={cancelCreate}
-              className="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm"
+              className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
             >
               Отмена
             </button>
@@ -292,49 +292,49 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
             const displayGroups = isExpanded ? groups : groups.slice(0, GROUPS_PREVIEW_LIMIT);
 
             return (
-              <div key={tag.id} className="bg-white border border-gray-200 rounded-lg p-4">
+              <div key={tag.id} className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
                 {editingTag?.id === tag.id ? (
                   /* Форма редактирования */
-                  <form onSubmit={handleUpdate} className="flex gap-2">
+                  <form onSubmit={handleUpdate} className="flex flex-col gap-3 sm:flex-row">
                     <input
                       type="text"
                       value={formData.name}
                       onChange={(e) => setFormData({ name: e.target.value })}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                       required
                     />
                     <button
                       type="submit"
-                      className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md text-sm"
+                      className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
                     >
                       Сохранить
                     </button>
                     <button
                       type="button"
                       onClick={cancelEdit}
-                      className="bg-gray-500 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm"
+                      className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
                     >
                       Отмена
                     </button>
                   </form>
                 ) : (
                   /* Отображение тега */
-                  <div className="space-y-3">
-                    <div className="flex justify-between items-center">
-                      <div>
-                        <h4 className="font-medium text-gray-900">{tag.name}</h4>
+                <div className="space-y-3">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="space-y-1">
+                        <h4 className="text-base font-semibold text-gray-900">{tag.name}</h4>
                         <p className="text-sm text-gray-500">slug: {tag.slug}</p>
                       </div>
-                      <div className="flex gap-2">
+                      <div className="flex flex-col gap-2 sm:flex-row">
                         <button
                           onClick={() => startEdit(tag)}
-                          className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                          className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                         >
                           Редактировать
                         </button>
                         <button
                           onClick={() => handleDelete(tag.id)}
-                          className="text-red-600 hover:text-red-800 text-sm font-medium"
+                          className="inline-flex items-center justify-center rounded-lg border border-red-200 px-4 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
                         >
                           Удалить
                         </button>
@@ -343,14 +343,14 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
 
                     {/* Группы под тегом */}
                     <div className="border-t pt-3">
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                         <h5 className="text-sm font-medium text-gray-700">
                           Группы ({groups.length})
                         </h5>
-                        <div className="flex gap-2">
+                        <div className="flex flex-col gap-2 sm:flex-row">
                           <button
                             onClick={() => setShowAddGroupModal(tag.id)}
-                            className="text-green-600 hover:text-green-800 text-sm font-medium"
+                            className="inline-flex items-center justify-center rounded-lg border border-green-200 px-3 py-2 text-xs font-semibold text-green-700 transition-colors hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
                             title="Добавить группу к тегу"
                           >
                             + Добавить
@@ -359,7 +359,7 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
                             <button
                               onClick={() => toggleGroupsExpansion(tag.id)}
                               disabled={isLoadingGroups}
-                              className="text-blue-600 hover:text-blue-800 text-sm font-medium disabled:opacity-50"
+                              className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-3 py-2 text-xs font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               {isLoadingGroups ? 'Загрузка...' : isExpanded ? 'Свернуть' : 'Показать все'}
                             </button>
@@ -368,17 +368,24 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
                       </div>
 
                       {isLoadingGroups ? (
-                        <div className="text-sm text-gray-500">Загрузка групп...</div>
+                        <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-4 text-sm text-gray-500">
+                          Загрузка групп...
+                        </div>
                       ) : groups.length === 0 ? (
-                        <div className="text-sm text-gray-500">Нет групп с этим тегом</div>
+                        <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-4 text-sm text-gray-500">
+                          Нет групп с этим тегом
+                        </div>
                       ) : (
                         <div className="space-y-1">
                           {displayGroups.map((group) => (
-                            <div key={group.id} className="flex items-center justify-between text-sm text-gray-600 bg-gray-50 px-2 py-1 rounded">
-                              <span>{group.name}</span>
+                            <div
+                              key={group.id}
+                              className="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                              <span className="font-medium text-gray-800">{group.name}</span>
                               <button
                                 onClick={() => handleRemoveGroupFromTag(tag.id, group.id)}
-                                className="text-red-500 hover:text-red-700 text-xs ml-2"
+                                className="inline-flex items-center justify-center rounded-md border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50"
                                 title="Отвязать группу от тега"
                               >
                                 ✕
@@ -386,7 +393,7 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
                             </div>
                           ))}
                           {hasMoreGroups && !isExpanded && (
-                            <div className="text-sm text-gray-500 italic">
+                            <div className="text-sm italic text-gray-500">
                               и еще {groups.length - GROUPS_PREVIEW_LIMIT} групп...
                             </div>
                           )}
@@ -403,28 +410,30 @@ const GroupTagList: React.FC<GroupTagListProps> = ({ eventumSlug }) => {
 
       {/* Модальное окно для добавления группы к тегу */}
       {showAddGroupModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-medium mb-4">Добавить группу к тегу</h3>
-            <div className="space-y-2 max-h-60 overflow-y-auto">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-gray-900">Добавить группу к тегу</h3>
+            <div className="mt-4 space-y-2 max-h-60 overflow-y-auto">
               {getAvailableGroupsForTag(showAddGroupModal).length === 0 ? (
-                <p className="text-gray-500 text-sm">Все группы уже привязаны к этому тегу</p>
+                <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+                  Все группы уже привязаны к этому тегу
+                </p>
               ) : (
                 getAvailableGroupsForTag(showAddGroupModal).map((group) => (
                   <button
                     key={group.id}
                     onClick={() => handleAddGroupToTag(showAddGroupModal, group.id)}
-                    className="w-full text-left px-3 py-2 text-sm bg-gray-50 hover:bg-gray-100 rounded border"
+                    className="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     {group.name}
                   </button>
                 ))
               )}
             </div>
-            <div className="flex justify-end mt-4">
+            <div className="mt-6 flex justify-end">
               <button
                 onClick={() => setShowAddGroupModal(null)}
-                className="px-4 py-2 text-sm bg-gray-500 hover:bg-gray-600 text-white rounded"
+                className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
               >
                 Отмена
               </button>

--- a/frontend/src/components/participant/ParticipantList.tsx
+++ b/frontend/src/components/participant/ParticipantList.tsx
@@ -33,17 +33,20 @@ const ParticipantList = ({ eventumSlug }: ParticipantListProps) => {
   if (error) return <p className="text-center text-red-400">{error}</p>;
 
   return (
-    <div className="mt-6">
+    <div className="mt-2 space-y-4">
       {participants.length > 0 ? (
-        <ul className="divide-y divide-gray-200">
+        <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-200 bg-gray-50">
           {participants.map((participant) => (
-            <li key={participant.id} className="py-3">
-              <p className="text-md text-gray-800">{participant.name}</p>
+            <li key={participant.id} className="flex flex-col gap-1 px-4 py-3 sm:px-6">
+              <span className="text-sm font-medium text-gray-900">{participant.name}</span>
+              <span className="text-xs text-gray-500">ID: {participant.id}</span>
             </li>
           ))}
         </ul>
       ) : (
-        <p className="text-gray-500">Участники еще не добавлены.</p>
+        <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
+          Участники еще не добавлены
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -49,129 +49,149 @@ const DashboardPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
       <Header />
 
-      {/* Main Content */}
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <div className="bg-white overflow-hidden shadow rounded-lg">
-            <div className="px-4 py-5 sm:p-6">
-              <div className="mb-6">
-                <h2 className="text-2xl font-bold text-gray-900">
-                  Панель управления
-                </h2>
-              </div>
-              
-              {user && (
-                <div className="space-y-6">
-                  {/* User Info */}
-                  <div className="bg-gray-50 rounded-lg p-6">
-                    <h3 className="text-lg font-medium text-gray-900 mb-4">
+      <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+        <section className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+          <div className="space-y-8 px-4 py-6 sm:px-8 sm:py-8">
+            <header className="space-y-2">
+              <p className="text-sm font-medium uppercase tracking-wide text-blue-600">
+                Личный кабинет
+              </p>
+              <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                Панель управления
+              </h1>
+            </header>
+
+            {user && (
+              <div className="space-y-10">
+                <section className="space-y-4">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <h2 className="text-lg font-semibold text-gray-900">
                       Информация о пользователе
-                    </h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700">
-                          Имя
-                        </label>
-                        <p className="mt-1 text-sm text-gray-900">{user.name}</p>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700">
-                          VK ID
-                        </label>
-                        <p className="mt-1 text-sm text-gray-900">{user.vk_id}</p>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700">
-                          Email
-                        </label>
-                        <p className="mt-1 text-sm text-gray-900">
-                          {user.email || 'Не указан'}
-                        </p>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700">
-                          Дата регистрации
-                        </label>
-                        <p className="mt-1 text-sm text-gray-900">
-                          {new Date(user.date_joined).toLocaleDateString('ru-RU')}
-                        </p>
-                      </div>
+                    </h2>
+                    <p className="text-sm text-gray-500">
+                      Проверьте актуальность данных профиля
+                    </p>
+                  </div>
+                  <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                      <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        Имя
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">{user.name}</dd>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                      <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        VK ID
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">{user.vk_id}</dd>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                      <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        Email
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {user.email || 'Не указан'}
+                      </dd>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                      <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        Дата регистрации
+                      </dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {new Date(user.date_joined).toLocaleDateString('ru-RU')}
+                      </dd>
+                    </div>
+                  </dl>
+                </section>
+
+                <section className="space-y-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="text-lg font-semibold text-gray-900">
+                        Мои группы мероприятий
+                      </h2>
+                      <p className="text-sm text-gray-500">
+                        Всего: {eventums.length}
+                      </p>
                     </div>
                   </div>
 
-                  {/* Eventums List */}
-                  <div className="space-y-4">
-                    <h3 className="text-lg font-medium text-gray-900">
-                      Мои группы мероприятий ({eventums.length})
-                    </h3>
-                    
-                    {loading ? (
-                      <div className="text-center py-8">
-                        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-                        <p className="mt-2 text-gray-600">Загрузка групп мероприятий...</p>
-                      </div>
-                    ) : eventums.length === 0 ? (
-                      <div className="text-center py-8 bg-gray-50 rounded-lg">
-                        <p className="text-gray-600">У вас пока нет групп мероприятий</p>
-                        <p className="text-sm text-gray-500 mt-1">Обратитесь к администратору для добавления в группу</p>
-                      </div>
-                    ) : (
-                      <div className="space-y-3">
-                        {eventums.map((eventum) => (
-                          <div key={eventum.id} className="border rounded-lg p-4 bg-white hover:bg-gray-50 transition-colors">
-                            <div className="flex justify-between items-start">
-                              <div className="flex-1">
-                                <div className="flex items-center space-x-3 mb-2">
-                                  <h4 className="text-lg font-medium text-gray-900">
-                                    {eventum.name}
-                                  </h4>
-                                  <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                                    eventum.user_role === 'organizer' 
-                                      ? 'bg-purple-100 text-purple-800' 
+                  {loading ? (
+                    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center">
+                      <div className="inline-block h-10 w-10 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"></div>
+                      <p className="text-sm font-medium text-gray-700">Загрузка групп мероприятий…</p>
+                      <p className="text-xs text-gray-500">Это может занять несколько секунд</p>
+                    </div>
+                  ) : eventums.length === 0 ? (
+                    <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center">
+                      <p className="text-base font-medium text-gray-700">
+                        У вас пока нет групп мероприятий
+                      </p>
+                      <p className="mt-2 text-sm text-gray-500">
+                        Обратитесь к администратору, чтобы получить доступ к нужной группе
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      {eventums.map((eventum) => (
+                        <article
+                          key={eventum.id}
+                          className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md sm:p-6"
+                        >
+                          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                            <div className="space-y-3">
+                              <div className="flex flex-wrap items-center gap-3">
+                                <h3 className="text-xl font-semibold text-gray-900">
+                                  {eventum.name}
+                                </h3>
+                                <span
+                                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                                    eventum.user_role === 'organizer'
+                                      ? 'bg-purple-100 text-purple-800'
                                       : 'bg-green-100 text-green-800'
-                                  }`}>
-                                    {eventum.user_role === 'organizer' ? 'Организатор' : 'Участник'}
-                                  </span>
-                                </div>
-                                {eventum.description && (
-                                  <p className="text-sm text-gray-700 mb-2">
-                                    {eventum.description}
-                                  </p>
-                                )}
-                                <div className="text-sm text-gray-500">
-                                  <p>Создано: {new Date(eventum.created_at).toLocaleDateString('ru-RU')}</p>
-                                </div>
-                              </div>
-                              <div className="flex space-x-2 ml-4">
-                                <button
-                                  onClick={() => navigate(`/${eventum.slug}`)}
-                                  className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm transition-colors"
+                                  }`}
                                 >
-                                  Перейти к группе
-                                </button>
-                                {eventum.user_role === 'organizer' && (
-                                  <button
-                                    onClick={() => navigate(`/${eventum.slug}/admin`)}
-                                    className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1 rounded text-sm transition-colors"
-                                  >
-                                    Админка
-                                  </button>
-                                )}
+                                  {eventum.user_role === 'organizer' ? 'Организатор' : 'Участник'}
+                                </span>
                               </div>
+                              {eventum.description && (
+                                <p className="text-sm leading-6 text-gray-600">
+                                  {eventum.description}
+                                </p>
+                              )}
+                              <p className="text-xs uppercase tracking-wide text-gray-500">
+                                Создано {new Date(eventum.created_at).toLocaleDateString('ru-RU')}
+                              </p>
+                            </div>
+
+                            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
+                              <button
+                                onClick={() => navigate(`/${eventum.slug}`)}
+                                className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                              >
+                                Перейти к группе
+                              </button>
+                              {eventum.user_role === 'organizer' && (
+                                <button
+                                  onClick={() => navigate(`/${eventum.slug}/admin`)}
+                                  className="inline-flex items-center justify-center rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+                                >
+                                  Админка
+                                </button>
+                              )}
                             </div>
                           </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
+                        </article>
+                      ))}
+                    </div>
+                  )}
+                </section>
+              </div>
+            )}
           </div>
-        </div>
+        </section>
       </main>
     </div>
   );

--- a/frontend/src/pages/EventumPage.tsx
+++ b/frontend/src/pages/EventumPage.tsx
@@ -47,46 +47,52 @@ const EventumPage = () => {
   };
 
   return (
-    <main className="min-h-screen p-4 md:p-8">
-      <div className="max-w-5xl mx-auto">
-        
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-3xl font-bold text-gray-900">{eventum.name}</h1>
+    <main className="min-h-screen bg-gray-50 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <p className="text-sm font-medium uppercase tracking-wide text-blue-600">
+              Группа мероприятий
+            </p>
+            <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+              {eventum.name}
+            </h1>
+          </div>
           <Link
             to={`/${eventumSlug}/admin`}
-            className="text-sm text-blue-600 hover:underline"
+            className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Админка
           </Link>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-4 md:p-6">
-          {/* Панель с вкладками */}
-          <div className="flex space-x-4 border-b border-gray-200 pb-4 mb-4">
-            <button
-              onClick={() => setActiveTab('participants')}
-              className={getTabClassName('participants')}
-            >
-              Участники
-            </button>
-            <button
-              onClick={() => setActiveTab('events')}
-              className={getTabClassName('events')}
-            >
-              Мероприятия
-            </button>
-          </div>
+        <section className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
+          <div className="space-y-6 px-4 py-6 sm:px-8 sm:py-8">
+            <div className="flex flex-wrap items-center gap-3 border-b border-gray-100 pb-4">
+              <button
+                onClick={() => setActiveTab('participants')}
+                className={getTabClassName('participants')}
+              >
+                Участники
+              </button>
+              <button
+                onClick={() => setActiveTab('events')}
+                className={getTabClassName('events')}
+              >
+                Мероприятия
+              </button>
+            </div>
 
-          {/* Содержимое вкладок */}
-          <div>
-            <div className={activeTab === 'participants' ? '' : 'hidden'}>
-              <ParticipantList eventumSlug={eventumSlug} />
-            </div>
-            <div className={activeTab === 'events' ? '' : 'hidden'}>
-              <EventList eventumSlug={eventumSlug} />
+            <div className="space-y-6">
+              <div className={activeTab === 'participants' ? 'block' : 'hidden'}>
+                <ParticipantList eventumSlug={eventumSlug} />
+              </div>
+              <div className={activeTab === 'events' ? 'block' : 'hidden'}>
+                <EventList eventumSlug={eventumSlug} />
+              </div>
             </div>
           </div>
-        </div>
+        </section>
       </div>
     </main>
   );

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -2,12 +2,14 @@ import { Link } from 'react-router-dom';
 
 const NotFoundPage = () => {
     return (
-        <div className="text-center">
-            <h1 className="text-6xl font-bold text-red-500">404</h1>
-            <p className="text-2xl mt-4">Страница не найдена</p>
+        <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 rounded-2xl bg-white/80 px-4 py-12 text-center shadow-sm backdrop-blur-sm">
+            <div>
+                <h1 className="text-5xl font-black text-gray-900 sm:text-6xl">404</h1>
+                <p className="mt-3 text-lg text-gray-600 sm:text-xl">Страница не найдена или была перемещена</p>
+            </div>
             <Link
                 to="/"
-                className="mt-8 inline-block bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+                className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
                 На главную
             </Link>

--- a/frontend/src/pages/admin/EventTagsPage.tsx
+++ b/frontend/src/pages/admin/EventTagsPage.tsx
@@ -13,14 +13,14 @@ const AdminEventTagsPage = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Теги мероприятий</h2>
-        <p className="text-gray-600">
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Теги мероприятий</h2>
+        <p className="text-sm text-gray-500">
           Управляйте тегами для категоризации мероприятий. Теги помогают организовать и фильтровать события.
         </p>
-      </div>
-      
+      </header>
+
       <EventTagList eventumSlug={eventumSlug} />
     </div>
   );

--- a/frontend/src/pages/admin/EventsPage.tsx
+++ b/frontend/src/pages/admin/EventsPage.tsx
@@ -43,46 +43,74 @@ const AdminEventsPage = () => {
   };
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">Мероприятия</h2>
-      <div className="mb-4 flex gap-4 flex-wrap">
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Мероприятия</h2>
+        <p className="text-sm text-gray-500">
+          Отфильтруйте список по названию или тегу и добавьте новые активности.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
         <input
           placeholder="Фильтр по названию"
           value={nameFilter}
           onChange={(e) => setNameFilter(e.target.value)}
-          className="border border-gray-300 rounded px-2 py-1"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 sm:max-w-xs"
         />
         <input
           placeholder="Фильтр по тегу"
           value={tagFilter}
           onChange={(e) => setTagFilter(e.target.value)}
-          className="border border-gray-300 rounded px-2 py-1"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 sm:max-w-xs"
         />
+        <span className="text-xs text-gray-500 sm:self-center">Показано: {filtered.length}</span>
       </div>
-      <ul className="space-y-2 mb-8">
+
+      <ul className="space-y-3">
         {filtered.map((ev) => (
           <li
             key={ev.id}
-            className="p-2 border border-gray-200 rounded bg-white"
+            className="rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm sm:px-6"
           >
-            {ev.name}
+            <p className="text-sm font-medium text-gray-900">{ev.name}</p>
           </li>
         ))}
+        {filtered.length === 0 && (
+          <li className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center text-sm text-gray-500">
+            Подходящих мероприятий не найдено
+          </li>
+        )}
       </ul>
-      <form onSubmit={handleAdd} className="space-y-2 max-w-md">
-        <h3 className="font-medium">Добавить мероприятие</h3>
-        <input
-          value={newName}
-          onChange={(e) => setNewName(e.target.value)}
-          placeholder="Название"
-          className="w-full border border-gray-300 rounded px-3 py-2"
-        />
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-        >
-          Добавить
-        </button>
+
+      <form
+        onSubmit={handleAdd}
+        className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6"
+      >
+        <div>
+          <h3 className="text-lg font-medium text-gray-900">Добавить мероприятие</h3>
+          <p className="text-sm text-gray-500">Создайте новый пункт в расписании</p>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700" htmlFor="event-name">
+            Название
+          </label>
+          <input
+            id="event-name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Введите название мероприятия"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          />
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Добавить
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/admin/GroupTagsPage.tsx
+++ b/frontend/src/pages/admin/GroupTagsPage.tsx
@@ -13,14 +13,14 @@ const AdminGroupTagsPage = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Теги групп</h2>
-        <p className="text-gray-600">
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Теги групп</h2>
+        <p className="text-sm text-gray-500">
           Управляйте тегами для категоризации групп участников. Теги помогают организовать и фильтровать группы.
         </p>
-      </div>
-      
+      </header>
+
       <GroupTagList eventumSlug={eventumSlug} />
     </div>
   );

--- a/frontend/src/pages/admin/GroupsPage.tsx
+++ b/frontend/src/pages/admin/GroupsPage.tsx
@@ -62,82 +62,107 @@ const AdminGroupsPage = () => {
   };
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">Группы участников</h2>
-      <button
-        className="mb-4 px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() => setShowForm(true)}
-      >
-        Добавить
-      </button>
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Группы участников</h2>
+        <p className="text-sm text-gray-500">
+          Создавайте группы, добавляйте участников и упрощайте массовую коммуникацию.
+        </p>
+      </header>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <button
+          className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          onClick={() => setShowForm(true)}
+        >
+          Добавить группу
+        </button>
+        <span className="text-xs text-gray-500">Всего групп: {filteredGroups.length}</span>
+      </div>
 
       {showForm && (
-        <div className="mb-6 border p-4 rounded bg-white">
-          <div className="mb-4">
+        <div className="space-y-5 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700" htmlFor="group-name">
+              Название группы
+            </label>
             <input
+              id="group-name"
               value={groupName}
               onChange={(e) => setGroupName(e.target.value)}
-              placeholder="Название группы"
-              className="w-full border border-gray-300 rounded px-2 py-1"
+              placeholder="Введите название"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             />
           </div>
 
-          <div className="mb-2 relative">
-            <input
-              value={participantQuery}
-              onChange={(e) => setParticipantQuery(e.target.value)}
-              placeholder="Добавить участника"
-              className="w-full border border-gray-300 rounded px-2 py-1"
-            />
-            {suggestions.length > 0 && (
-              <ul className="absolute z-10 bg-white border border-gray-200 w-full mt-1 max-h-40 overflow-y-auto">
-                {suggestions.map((p) => (
-                  <li
-                    key={p.id}
-                    className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
-                    onClick={() => addParticipant(p)}
-                  >
-                    {p.name}
-                  </li>
-                ))}
-              </ul>
-            )}
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700" htmlFor="participant-search">
+              Добавить участника
+            </label>
+            <div className="relative">
+              <input
+                id="participant-search"
+                value={participantQuery}
+                onChange={(e) => setParticipantQuery(e.target.value)}
+                placeholder="Начните вводить имя"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+              {suggestions.length > 0 && (
+                <ul className="absolute z-20 mt-2 max-h-48 w-full overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg">
+                  {suggestions.map((p) => (
+                    <li
+                      key={p.id}
+                      className="cursor-pointer px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      onClick={() => addParticipant(p)}
+                    >
+                      {p.name}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           </div>
 
-          <div className="flex flex-wrap gap-2 mb-4">
-            {selectedParticipants.slice(0, 5).map((p) => (
-              <span
-                key={p.id}
-                className="flex items-center bg-gray-200 px-2 py-1 rounded"
-              >
-                {p.name}
-                <button
-                  className="ml-1 text-gray-600"
-                  onClick={() => removeParticipant(p.id)}
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-gray-700">Выбранные участники</p>
+            <div className="flex flex-wrap gap-2">
+              {selectedParticipants.slice(0, 5).map((p) => (
+                <span
+                  key={p.id}
+                  className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700"
                 >
-                  ×
-                </button>
-              </span>
-            ))}
-            {selectedParticipants.length > 5 && (
-              <span className="flex items-center bg-gray-200 px-2 py-1 rounded">
-                Показать всех ({selectedParticipants.length})
-              </span>
-            )}
+                  {p.name}
+                  <button
+                    className="ml-2 text-blue-500 hover:text-blue-700"
+                    onClick={() => removeParticipant(p.id)}
+                    type="button"
+                    aria-label={`Удалить ${p.name}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              {selectedParticipants.length > 5 && (
+                <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">
+                  Показать всех ({selectedParticipants.length})
+                </span>
+              )}
+            </div>
           </div>
 
           {/* TODO: выбор участников по тегам */}
 
-          <div className="flex gap-2">
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
             <button
-              className="px-4 py-2 bg-green-500 text-white rounded"
+              className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
               onClick={handleSave}
+              type="button"
             >
               Сохранить
             </button>
             <button
-              className="px-4 py-2 bg-gray-300 rounded"
+              className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
               onClick={() => setShowForm(false)}
+              type="button"
             >
               Отмена
             </button>
@@ -149,7 +174,7 @@ const AdminGroupsPage = () => {
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
         placeholder="Поиск группы"
-        className="mb-4 w-full border border-gray-300 rounded px-2 py-1"
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
       />
 
       <div className="space-y-4">
@@ -158,23 +183,31 @@ const AdminGroupsPage = () => {
             .map((id) => participants.find((p) => p.id === id)?.name)
             .filter(Boolean) as string[];
           return (
-            <div key={g.id} className="border p-4 rounded bg-white">
-              <h3 className="font-semibold mb-2">{g.name}</h3>
-              <div className="flex flex-wrap gap-2">
+            <article key={g.id} className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <h3 className="text-lg font-semibold text-gray-900">{g.name}</h3>
+                <span className="text-xs text-gray-500">Участников: {groupParticipants.length}</span>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
                 {groupParticipants.slice(0, 5).map((name, idx) => (
-                  <span key={idx} className="bg-gray-200 px-2 py-1 rounded">
+                  <span key={idx} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
                     {name}
                   </span>
                 ))}
                 {groupParticipants.length > 5 && (
-                  <button className="bg-gray-200 px-2 py-1 rounded">
+                  <button className="inline-flex items-center rounded-full bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700">
                     Показать всех
                   </button>
                 )}
               </div>
-            </div>
+            </article>
           );
         })}
+        {filteredGroups.length === 0 && (
+          <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center text-sm text-gray-500">
+            Группы не найдены
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/InfoPage.tsx
+++ b/frontend/src/pages/admin/InfoPage.tsx
@@ -18,25 +18,37 @@ const AdminInfoPage = () => {
   };
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">Общая информация</h2>
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+    <div className="mx-auto w-full max-w-2xl space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Общая информация</h2>
+        <p className="text-sm text-gray-500">
+          Обновите название группы мероприятий. Изменения вступят в силу сразу после сохранения.
+        </p>
+      </header>
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-5 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6"
+      >
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700" htmlFor="eventum-name">
             Название
           </label>
           <input
-            className="w-full border border-gray-300 rounded px-3 py-2"
+            id="eventum-name"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            placeholder="Введите название"
           />
         </div>
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-        >
-          Сохранить
-        </button>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Сохранить
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/admin/ParticipantsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantsPage.tsx
@@ -19,22 +19,37 @@ const AdminParticipantsPage = () => {
   );
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">Участники</h2>
-      <div className="mb-4 flex gap-4 flex-wrap">
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-gray-900">Участники</h2>
+        <p className="text-sm text-gray-500">
+          Найдите участника по имени и управляйте списком участников группы.
+        </p>
+      </header>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
         <input
           placeholder="Фильтр по имени"
           value={nameFilter}
           onChange={(e) => setNameFilter(e.target.value)}
-          className="border border-gray-300 rounded px-2 py-1"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 sm:w-auto"
         />
+        <span className="text-xs text-gray-500">Всего: {filtered.length}</span>
       </div>
-      <ul className="space-y-2">
+      <ul className="space-y-3">
         {filtered.map((p) => (
-          <li key={p.id} className="p-2 border border-gray-200 rounded bg-white">
-            {p.name}
+          <li
+            key={p.id}
+            className="flex flex-col gap-1 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+          >
+            <span className="text-sm font-medium text-gray-900">{p.name}</span>
+            <span className="text-xs text-gray-500">ID: {p.id}</span>
           </li>
         ))}
+        {filtered.length === 0 && (
+          <li className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center text-sm text-gray-500">
+            Подходящих участников не найдено
+          </li>
+        )}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement responsive navigation, header controls, and layout spacing for public and admin shells
- restyle dashboard, event view, authentication, and not-found pages with adaptive card-based sections
- modernize admin lists and forms for events, participants, tags, and groups with mobile-friendly flex layouts

## Testing
- npm run lint *(fails: existing `any` usage in API/SDK helpers and legacy context exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d6aa7bdc84832892b1975330cd6803