### PR TITLE
Improve admin and public layouts with responsive refinements

### DIFF
--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -67,7 +67,7 @@ const AdminLayout = () => {
   };
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
+    <div className="flex h-screen flex-col overflow-hidden bg-gray-50">
       {/* Top bar across the page */}
       <Header
         variant="admin"
@@ -77,7 +77,7 @@ const AdminLayout = () => {
       />
 
       {/* Content row: sidebar + page */}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Backdrop for mobile menu */}
         {isMobileMenuOpen && (
           <button
@@ -90,61 +90,63 @@ const AdminLayout = () => {
 
         {/* Sidebar */}
         <aside
-          className={`${
+          className={`fixed top-14 bottom-0 left-0 z-30 w-64 translate-x-0 transform border-r border-gray-200 bg-white pb-3 pl-0 pr-2 pt-2 shadow-lg transition-transform duration-200 ease-in-out lg:static lg:h-full lg:translate-x-0 lg:shadow-none ${
             collapsed ? "lg:w-20" : "lg:w-64"
-          } fixed top-14 bottom-0 left-0 z-30 w-64 transform bg-white border-r border-gray-200 pt-2 pb-3 pl-0 pr-2 flex flex-col transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 lg:h-full ${
-            isMobileMenuOpen ? "translate-x-0" : "-translate-x-full"
-          }`}
+          } ${isMobileMenuOpen ? "translate-x-0" : "-translate-x-full"}`}
           aria-label="Админ-меню"
         >
-          <div className="flex-1 overflow-y-auto">
-            <nav className="space-y-1">
-              {menu.map((item) => {
-                const Icon = item.icon;
-                return (
-                  <NavLink
-                    key={item.to}
-                    to={item.to}
-                    end={item.end}
-                    title={item.label}
-                    aria-label={item.label}
-                    className={({ isActive }) =>
-                      `flex items-center justify-start gap-3 px-3 py-2 rounded text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors border-l-4 ${
-                        isActive ? "bg-gray-100 font-medium border-blue-600" : "border-transparent"
-                      } ${collapsed ? "lg:justify-center lg:px-2 lg:border-l-0" : ""}`
-                    }
-                  >
-                    <Icon className="shrink-0 text-gray-600" />
-                    <span
-                      className={`${
-                        collapsed ? "lg:hidden" : ""
-                      } text-sm whitespace-nowrap`}
+          <div className="flex h-full flex-col overflow-hidden">
+            <div className="flex-1 overflow-y-auto px-2">
+              <nav className="space-y-1">
+                {menu.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      end={item.end}
+                      title={item.label}
+                      aria-label={item.label}
+                      className={({ isActive }) =>
+                        `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                          isActive
+                            ? "bg-blue-50 text-blue-700"
+                            : "hover:bg-gray-100"
+                        } ${collapsed ? "lg:justify-center lg:px-2" : ""}`
+                      }
                     >
-                      {item.label}
-                    </span>
-                  </NavLink>
-                );
-              })}
-            </nav>
-          </div>
-          <div className="mt-auto px-1">
-            <button
-              type="button"
-              onClick={() => setCollapsed((c) => !c)}
-              className="w-full flex items-center justify-center gap-2 px-2 py-2 rounded border border-gray-200 hover:bg-gray-100 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              aria-label={collapsed ? "Раскрыть меню" : "Скрыть меню"}
-              aria-expanded={!collapsed}
-            >
-              <AsideToggleIcon />
-              <span className={`text-sm ${collapsed ? 'hidden' : ''}`}>
-                {collapsed ? "" : "Свернуть"}
-              </span>
-            </button>
+                      <Icon className="shrink-0" />
+                      <span
+                        className={`whitespace-nowrap transition-opacity duration-150 ${
+                          collapsed ? "lg:invisible lg:w-0 lg:opacity-0" : ""
+                        }`}
+                      >
+                        {item.label}
+                      </span>
+                    </NavLink>
+                  );
+                })}
+              </nav>
+            </div>
+            <div className="mt-auto border-t border-gray-200 px-2 pt-3">
+              <button
+                type="button"
+                onClick={() => setCollapsed((c) => !c)}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 px-2 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-label={collapsed ? "Раскрыть меню" : "Скрыть меню"}
+                aria-expanded={!collapsed}
+              >
+                <AsideToggleIcon />
+                <span className={`${collapsed ? "hidden" : ""}`}>
+                  Свернуть
+                </span>
+              </button>
+            </div>
           </div>
         </aside>
 
         {/* Page content */}
-        <main className="flex-1 min-w-0 p-4 sm:p-6 lg:p-8 overflow-y-auto">
+        <main className="min-w-0 flex-1 overflow-y-auto bg-gray-50 p-4 sm:p-6 lg:p-8">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -86,9 +86,9 @@ const DashboardPage: React.FC = () => {
 
       <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
         {/* Профиль пользователя */}
-        <section className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-100 mb-8">
+        <section className="mb-8 rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
           <div className="px-4 py-6 sm:px-8 sm:py-8">
-            <div className="flex items-center space-x-6">
+            <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
               {user?.avatar_url ? (
                 <img
                   src={user.avatar_url}
@@ -96,14 +96,16 @@ const DashboardPage: React.FC = () => {
                   className="h-20 w-20 rounded-full object-cover ring-4 ring-white shadow-lg"
                 />
               ) : (
-                <div className="h-20 w-20 rounded-full bg-gray-300 flex items-center justify-center ring-4 ring-white shadow-lg">
-                  <span className="text-2xl font-semibold text-gray-600">
+                <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 ring-4 ring-white shadow-lg">
+                  <span className="text-2xl font-semibold text-white">
                     {user?.name?.charAt(0)?.toUpperCase() || 'U'}
                   </span>
                 </div>
               )}
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">{user?.name}</h1>
+              <div className="space-y-1">
+                <p className="text-sm uppercase tracking-wide text-gray-400">Личный кабинет</p>
+                <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">{user?.name}</h1>
+                {user?.email && <p className="text-sm text-gray-500">{user.email}</p>}
               </div>
             </div>
           </div>
@@ -112,20 +114,20 @@ const DashboardPage: React.FC = () => {
         {/* Мои события */}
         <section className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
           <div className="px-4 py-6 sm:px-8 sm:py-8">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+            <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h2 className="text-lg font-semibold text-gray-900">
+                <h2 className="text-lg font-semibold text-gray-900 sm:text-xl">
                   Мои события
                 </h2>
                 <p className="text-sm text-gray-500">
                   Всего: {eventums.length}
                 </p>
               </div>
-                <button
-                  onClick={handleCreateEventum}
-                  className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <button
+                onClick={handleCreateEventum}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
                 Создать событие
@@ -144,10 +146,18 @@ const DashboardPage: React.FC = () => {
                   <article
                     key={eventum.id}
                     onClick={() => navigate(`/${eventum.slug}`)}
-                    className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md cursor-pointer sm:p-6"
+                    className="cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:p-6"
+                    tabIndex={0}
+                    role="button"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        navigate(`/${eventum.slug}`);
+                      }
+                    }}
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                      <div className="space-y-3 flex-1">
+                      <div className="flex-1 space-y-3">
                         <div className="flex flex-wrap items-center gap-3">
                           <h3 className="text-xl font-semibold text-gray-900">
                             {eventum.name}
@@ -162,12 +172,18 @@ const DashboardPage: React.FC = () => {
                             {eventum.user_role === 'organizer' ? 'Организатор' : 'Участник'}
                           </span>
                         </div>
-                        
+
                         {eventum.description && (
                           <p className="text-sm text-gray-600">
                             {eventum.description}
                           </p>
                         )}
+
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 sm:text-sm">
+                          <span>Создан: {new Date(eventum.created_at).toLocaleDateString('ru-RU')}</span>
+                          <span className="hidden sm:inline">•</span>
+                          <span>Слаг: {eventum.slug}</span>
+                        </div>
                       </div>
 
                       {eventum.user_role === 'organizer' && (

--- a/frontend/src/pages/EventumPage.tsx
+++ b/frontend/src/pages/EventumPage.tsx
@@ -4,52 +4,55 @@ const EventumPage = () => {
   const { eventumSlug } = useParams<{ eventumSlug: string }>();
 
   return (
-    <main className="min-h-screen bg-gray-50 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-2">
-
-            <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
-              {eventumSlug}
-            </h1>
-          </div>
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <div className="flex flex-col gap-4 rounded-2xl bg-gradient-to-br from-blue-50 via-white to-purple-50 p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:p-8">
+        <div className="space-y-2">
+          <p className="text-sm uppercase tracking-wide text-blue-600">eventum</p>
+          <h1 className="text-balance text-3xl font-bold text-gray-900 sm:text-4xl">
+            {eventumSlug}
+          </h1>
+          <p className="text-sm text-gray-600">
+            Страница для участников с расписанием, материалами и объявлениями появится здесь позже.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:items-end">
           <Link
             to={`/${eventumSlug}/admin`}
-            className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-blue-200 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.75v10.5m5.25-5.25H6.75" />
+            </svg>
             Админка
           </Link>
+          <span className="text-xs text-gray-400">Доступна только организаторам</span>
         </div>
-
-        <section className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-100">
-          <div className="px-4 py-6 sm:px-8 sm:py-8">
-            <div className="text-center">
-              <div className="mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-blue-100">
-                <svg
-                  className="h-12 w-12 text-blue-600"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="1.5"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
-                  />
-                </svg>
-              </div>
-              <h2 className="mt-6 text-2xl font-bold text-gray-900">
-                Скоро здесь будет полезная информация
-              </h2>
-              <p className="mt-4 text-lg text-gray-600">
-                На этой странице будет размещена вся необходимая информация для участников событий.
-              </p>
-            </div>
-          </div>
-        </section>
       </div>
-    </main>
+
+      <section className="overflow-hidden rounded-2xl border border-dashed border-gray-200 bg-white/80 p-6 text-center shadow-sm backdrop-blur-sm sm:p-10">
+        <div className="mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-blue-100">
+          <svg
+            className="h-12 w-12 text-blue-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+            />
+          </svg>
+        </div>
+        <h2 className="mt-6 text-2xl font-bold text-gray-900 sm:text-3xl">
+          Скоро здесь будет полезная информация
+        </h2>
+        <p className="mt-4 text-base leading-relaxed text-gray-600">
+          Мы готовим подробную страницу с расписанием, материалами и важными объявлениями. Следите за обновлениями — мы обязательно уведомим участников, когда все будет готово.
+        </p>
+      </section>
+    </div>
   );
 };
 

--- a/frontend/src/pages/admin/EventsPage.tsx
+++ b/frontend/src/pages/admin/EventsPage.tsx
@@ -277,73 +277,73 @@ const AdminEventsPage = () => {
             return (
               <div
                 key={event.id}
-                className={`rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm transition-all duration-200 ${
-                  isExpanded ? 'min-h-[100px]' : 'h-16'
+                className={`rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm transition-all duration-200 ${
+                  isExpanded ? 'ring-1 ring-blue-100' : ''
                 }`}
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4 flex-1 min-w-0">
-                    {/* Время */}
-                    <div className="text-sm text-gray-600 flex-shrink-0">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 sm:flex-1 sm:min-w-0">
+                    <div className="text-sm text-gray-600">
                       <span className="whitespace-nowrap">{formatEventTime(event.start_time, event.end_time)}</span>
                     </div>
-                    
-                    {/* Название */}
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-medium text-gray-900 truncate">{event.name}</h3>
-                    </div>
-                    
-                    {/* Теги */}
-                    <div className="flex items-center gap-1 flex-shrink-0">
-                      <div className="flex items-center gap-1">
-                        {displayTags.length > 0 ? (
-                          displayTags.map((tag) => (
-                            <span
-                              key={tag.id}
-                              className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
-                            >
-                              {tag.name}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="text-xs text-gray-400">Нет тегов</span>
-                        )}
-                        {hasMoreTags && !isExpanded && (
-                          <button
-                            onClick={() => toggleEventExpansion(event.id)}
-                            className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200"
-                          >
-                            <IconEllipsisHorizontal size={12} />
-                          </button>
-                        )}
-                        {isExpanded && (
-                          <button
-                            onClick={() => toggleEventExpansion(event.id)}
-                            className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200"
-                          >
-                            Скрыть
-                          </button>
-                        )}
-                      </div>
+                      <h3 className="truncate text-sm font-semibold text-gray-900 sm:text-base">{event.name}</h3>
+                      {event.description && isExpanded && (
+                        <p className="mt-1 text-xs text-gray-500 sm:text-sm">
+                          {event.description}
+                        </p>
+                      )}
                     </div>
                   </div>
-                  
-                  {/* Действия */}
-                  <div className="flex items-center gap-2 ml-4 flex-shrink-0">
-                    <button
-                      onClick={() => openEditModal(event)}
-                      className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-                      title="Редактировать"
-                    >
-                      <IconPencil size={16} />
-                    </button>
-                    <button
-                      onClick={() => handleDeleteEvent(event.id)}
-                      className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50"
-                      title="Удалить"
-                    >
-                      <IconTrash size={16} />
-                    </button>
+
+                  <div className="flex items-start justify-between gap-3 sm:justify-end">
+                    <div className="flex flex-wrap items-center gap-1">
+                      {displayTags.length > 0 ? (
+                        displayTags.map((tag) => (
+                          <span
+                            key={tag.id}
+                            className="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700"
+                          >
+                            {tag.name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-xs text-gray-400">Нет тегов</span>
+                      )}
+                      {hasMoreTags && !isExpanded && (
+                        <button
+                          onClick={() => toggleEventExpansion(event.id)}
+                          className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200"
+                        >
+                          <IconEllipsisHorizontal size={12} />
+                        </button>
+                      )}
+                      {isExpanded && (
+                        <button
+                          onClick={() => toggleEventExpansion(event.id)}
+                          className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-200"
+                        >
+                          Скрыть
+                        </button>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => openEditModal(event)}
+                        className="inline-flex items-center justify-center rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                        title="Редактировать"
+                      >
+                        <IconPencil size={16} />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteEvent(event.id)}
+                        className="inline-flex items-center justify-center rounded-lg p-2 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                        title="Удалить"
+                      >
+                        <IconTrash size={16} />
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/admin/EventumInfoPage.tsx
+++ b/frontend/src/pages/admin/EventumInfoPage.tsx
@@ -188,19 +188,15 @@ const EventumInfoPage = () => {
     <div className="space-y-6">
       {/* Заголовок с названием мероприятия */}
       <header className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex-1">
             {isEditingName ? (
-              <div className="flex items-center gap-3 min-w-0 flex-1">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                 <input
                   type="text"
                   value={tempName}
                   onChange={(e) => setTempName(e.target.value)}
-                  className="text-3xl font-bold text-gray-900 bg-transparent border-b-2 border-blue-500 focus:outline-none focus:border-blue-600 min-w-0 flex-1"
-                  style={{ 
-                    minWidth: `${Math.max(tempName.length * 20, 300)}px`,
-                    width: 'auto'
-                  }}
+                  className="w-full rounded-lg border border-blue-300 bg-white px-3 py-2 text-2xl font-semibold text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
                   autoFocus
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
@@ -210,30 +206,32 @@ const EventumInfoPage = () => {
                     }
                   }}
                 />
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={handleSaveName}
-                    className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                    className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1"
                   >
                     Сохранить
                   </button>
                   <button
                     onClick={handleCancelNameEdit}
-                    className="px-3 py-1.5 text-sm bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+                    className="inline-flex items-center justify-center rounded-lg bg-gray-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1"
                   >
                     Отменить
                   </button>
                 </div>
               </div>
             ) : (
-              <div className="flex items-center gap-3">
-                <h1 className="text-3xl font-bold text-gray-900">{eventum.name}</h1>
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="text-balance text-3xl font-bold text-gray-900 sm:text-4xl">
+                  {eventum.name}
+                </h1>
                 <button
                   onClick={() => setIsEditingName(true)}
-                  className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                  className="rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
                   title="Редактировать название"
                 >
-                  <IconPencil size={20} />
+                  <IconPencil size={18} />
                 </button>
               </div>
             )}
@@ -243,24 +241,26 @@ const EventumInfoPage = () => {
 
       {/* Описание мероприятия */}
       <section className="space-y-3">
-        <div className="flex items-center justify-end">
-          <button
-            onClick={() => setIsEditingDescription(true)}
-            className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-            title="Редактировать описание"
-          >
-            <IconPencil size={16} />
-          </button>
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Описание</h2>
+          {!isEditingDescription && (
+            <button
+              onClick={() => setIsEditingDescription(true)}
+              className="inline-flex items-center gap-2 rounded-full border border-gray-200 px-3 py-1.5 text-sm text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-700"
+            >
+              <IconPencil size={14} />
+              Редактировать
+            </button>
+          )}
         </div>
-        
-        <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
           {isEditingDescription ? (
-            <div className="space-y-3">
+            <div className="space-y-4">
               <textarea
                 value={tempDescription}
                 onChange={(e) => setTempDescription(e.target.value)}
-                className="w-full bg-transparent border-none focus:outline-none resize-none"
-                rows={4}
+                className="h-40 w-full resize-none rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100 sm:text-base"
                 placeholder="Введите описание мероприятия..."
                 autoFocus
                 onKeyDown={(e) => {
@@ -271,30 +271,32 @@ const EventumInfoPage = () => {
                   }
                 }}
               />
-              <div className="flex items-center justify-end gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 <button
                   onClick={handleSaveDescription}
-                  className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                  className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1"
                 >
                   Сохранить
                 </button>
                 <button
                   onClick={handleCancelDescriptionEdit}
-                  className="px-3 py-1.5 text-sm bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
+                  className="inline-flex items-center justify-center rounded-lg bg-gray-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1"
                 >
                   Отменить
                 </button>
               </div>
             </div>
           ) : (
-            <p className="text-gray-700 whitespace-pre-wrap">
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-700 sm:text-base">
               {eventum.description || (
-                <span 
-                  className="text-gray-400 cursor-pointer hover:text-gray-500 transition-colors"
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-2 text-left text-gray-400 transition-colors hover:text-gray-500"
                   onClick={() => setIsEditingDescription(true)}
                 >
+                  <IconPencil size={14} />
                   Описание мероприятия не указано
-                </span>
+                </button>
               )}
             </p>
           )}
@@ -340,49 +342,55 @@ const EventumInfoPage = () => {
         </div>
         
         <div className="bg-white border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-md font-medium text-gray-900">Организаторы</h3>
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h3 className="text-base font-semibold text-gray-900">Организаторы</h3>
             <button
               onClick={handleAddOrganizer}
-              className="flex items-center gap-2 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
             >
               <IconPlus size={14} />
-              Добавить
+              Добавить организатора
             </button>
           </div>
-          
+
           {eventum.organizers && eventum.organizers.length > 0 ? (
-            <div className="space-y-2">
+            <div className="space-y-3">
               {eventum.organizers.map((organizerRole) => (
                 <div
                   key={organizerRole.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                  className="rounded-xl border border-gray-200 bg-gray-50 p-3 sm:p-4"
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
-                      <span className="text-white text-sm font-medium">
-                        {organizerRole.user.name.charAt(0).toUpperCase()}
-                      </span>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white">
+                        <span className="text-base font-semibold">
+                          {organizerRole.user.name.charAt(0).toUpperCase()}
+                        </span>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-gray-900 sm:text-base">
+                          {organizerRole.user.name}
+                        </p>
+                        <p className="truncate text-xs text-gray-500 sm:text-sm">
+                          {organizerRole.user.email}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="font-medium text-gray-900">{organizerRole.user.name}</p>
-                      <p className="text-sm text-gray-500">{organizerRole.user.email}</p>
-                    </div>
+                    {organizerRole.user.id !== user?.id && (
+                      <button
+                        onClick={() => handleRemoveOrganizer(organizerRole.id, organizerRole.user.id)}
+                        className="inline-flex items-center justify-center rounded-full p-2 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                        title="Удалить организатора"
+                      >
+                        <IconTrash size={16} />
+                      </button>
+                    )}
                   </div>
-                  {organizerRole.user.id !== user?.id && (
-                    <button
-                      onClick={() => handleRemoveOrganizer(organizerRole.id, organizerRole.user.id)}
-                      className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors"
-                      title="Удалить организатора"
-                    >
-                      <IconTrash size={16} />
-                    </button>
-                  )}
                 </div>
               ))}
             </div>
           ) : (
-            <div className="text-center py-6 text-gray-500">
+            <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-500">
               <p>Организаторы не назначены</p>
             </div>
           )}
@@ -390,20 +398,28 @@ const EventumInfoPage = () => {
       </section>
 
       {/* Модальное окно добавления организатора */}
-      {isAddOrganizerModalOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-gray-900">Добавить организатора</h3>
-              <button
-                onClick={closeAddOrganizerModal}
-                className="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-              >
-                <IconX size={20} />
-              </button>
-            </div>
-            
-            <div className="space-y-4">
+        {isAddOrganizerModalOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6">
+            <div
+              className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="add-organizer-title"
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <h3 id="add-organizer-title" className="text-lg font-semibold text-gray-900">
+                  Добавить организатора
+                </h3>
+                <button
+                  onClick={closeAddOrganizerModal}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                  aria-label="Закрыть"
+                >
+                  <IconX size={20} />
+                </button>
+              </div>
+
+              <div className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Поиск пользователей
@@ -427,31 +443,31 @@ const EventumInfoPage = () => {
                 </div>
               )}
               
-              {searchResults.length > 0 && (
-                <div className="max-h-60 overflow-y-auto">
-                  <div className="space-y-2">
-                    {searchResults.map((user) => (
-                      <div
-                        key={user.id}
-                        className="flex items-center justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50"
-                      >
-                        <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
-                            <span className="text-white text-sm font-medium">
-                              {user.name.charAt(0).toUpperCase()}
-                            </span>
-                          </div>
-                          <div>
-                            <p className="font-medium text-gray-900">{user.name}</p>
-                            <p className="text-sm text-gray-500">{user.email}</p>
-                          </div>
-                        </div>
-                        <button
-                          onClick={() => handleAddUserAsOrganizer(user.id)}
-                          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                {searchResults.length > 0 && (
+                  <div className="max-h-60 overflow-y-auto pr-1">
+                    <div className="space-y-2">
+                      {searchResults.map((user) => (
+                        <div
+                          key={user.id}
+                          className="flex flex-col gap-3 rounded-lg border border-gray-200 p-3 transition-colors hover:bg-gray-50 sm:flex-row sm:items-center sm:justify-between"
                         >
-                          Добавить
-                        </button>
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500 text-white">
+                              <span className="text-sm font-semibold">
+                                {user.name.charAt(0).toUpperCase()}
+                              </span>
+                            </div>
+                            <div>
+                              <p className="text-sm font-semibold text-gray-900">{user.name}</p>
+                              <p className="text-xs text-gray-500 sm:text-sm">{user.email}</p>
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => handleAddUserAsOrganizer(user.id)}
+                            className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                          >
+                            Добавить
+                          </button>
                       </div>
                     ))}
                   </div>
@@ -465,13 +481,13 @@ const EventumInfoPage = () => {
               )}
             </div>
             
-            <div className="flex items-center justify-end gap-2 mt-6">
-              <button
-                onClick={closeAddOrganizerModal}
-                className="px-4 py-2 text-sm bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"
-              >
-                Отменить
-              </button>
+              <div className="mt-6 flex items-center justify-end gap-2">
+                <button
+                  onClick={closeAddOrganizerModal}
+                  className="inline-flex items-center justify-center rounded-lg bg-gray-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1"
+                >
+                  Отменить
+                </button>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/admin/ParticipantsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantsPage.tsx
@@ -130,10 +130,10 @@ const AdminParticipantsPage = () => {
       </header>
 
       {/* Кнопка добавления */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <button
           onClick={handleCreateParticipant}
-          className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
         >
           <IconPlus size={16} />
           Добавить участника
@@ -178,7 +178,7 @@ const AdminParticipantsPage = () => {
 
         </div>
 
-          <span className="text-xs text-gray-500 whitespace-nowrap">Всего: {filteredParticipants.length}</span>
+        <span className="text-xs text-gray-500 whitespace-nowrap">Всего: {filteredParticipants.length}</span>
       </div>
 
       {/* Список участников */}
@@ -192,84 +192,90 @@ const AdminParticipantsPage = () => {
             return (
               <li
                 key={participant.id}
-                className="flex items-center gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm"
+                className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
               >
-                {/* Аватарка или иконка участника слева */}
-                {participant.user?.avatar_url ? (
-                  <img
-                    src={participant.user.avatar_url}
-                    alt={participant.name}
-                    className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                    onError={(e) => {
-                      // Если аватарка не загрузилась, заменяем на иконку
-                      const target = e.currentTarget as HTMLImageElement;
-                      const nextElement = target.nextElementSibling as HTMLElement;
-                      if (target) target.style.display = 'none';
-                      if (nextElement) nextElement.style.display = 'block';
-                    }}
-                  />
-                ) : null}
-                <IconUser 
-                  size={20} 
-                  className={`text-gray-400 flex-shrink-0 ${participant.user?.avatar_url ? 'hidden' : ''}`}
-                />
-                
-                {/* Основная информация */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-sm font-medium text-gray-900 truncate">
-                      {participant.name}
-                    </span>
-                    {vkUrl && (
-                      <a
-                        href={vkUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-blue-600 hover:text-blue-800 text-xs"
-                      >
-                        <IconExternalLink size={12} />
-                        ВК
-                      </a>
-                    )}
-                  </div>
-                  
-                  {/* Группы участника */}
-                  {participant.groups && participant.groups.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {participant.groups.map((group) => (
-                        <span
-                          key={group.id}
-                          className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
-                        >
-                          {group.name}
-                        </span>
-                      ))}
+                <div className="flex items-center gap-4">
+                    <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+                      {participant.user?.avatar_url ? (
+                        <>
+                          <img
+                            src={participant.user.avatar_url}
+                            alt={participant.name}
+                            className="h-12 w-12 rounded-full object-cover"
+                            onError={(e) => {
+                              const fallback = e.currentTarget.nextElementSibling as HTMLElement;
+                              if (fallback) {
+                                fallback.classList.remove('hidden');
+                              }
+                              e.currentTarget.remove();
+                            }}
+                          />
+                          <div className="avatar-fallback hidden flex h-full w-full items-center justify-center">
+                            <IconUser size={20} />
+                          </div>
+                        </>
+                      ) : (
+                        <IconUser size={20} />
+                      )}
                     </div>
-                  )}
-                </div>
-                
-                {/* Кнопки действий справа */}
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  <button
-                    onClick={() => handleEditParticipant(participant)}
-                    className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                    title="Редактировать"
-                  >
-                    <IconPencil size={16} />
-                  </button>
-                  <button
-                    onClick={() => handleDeleteParticipant(participant)}
-                    disabled={deletingParticipantId === participant.id}
-                    className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                    title="Удалить"
-                  >
-                    {deletingParticipantId === participant.id ? (
-                      <div className="animate-spin w-4 h-4 border-2 border-gray-300 border-t-gray-600 rounded-full"></div>
-                    ) : (
-                      <IconTrash size={16} />
-                    )}
-                  </button>
-                </div>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-semibold text-gray-900">
+                          {participant.name}
+                        </span>
+                        {vkUrl && (
+                          <a
+                            href={vkUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100"
+                          >
+                            <IconExternalLink size={12} /> VK
+                          </a>
+                        )}
+                      </div>
+
+                      {participant.groups && participant.groups.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {participant.groups.map((group) => (
+                            <span
+                              key={group.id}
+                              className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-700"
+                            >
+                              {group.name}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      onClick={() => handleEditParticipant(participant)}
+                      className="inline-flex items-center justify-center rounded-lg border border-gray-200 p-2 text-gray-500 transition-colors hover:border-blue-500 hover:text-blue-600"
+                      title="Редактировать"
+                    >
+                      <IconPencil size={16} />
+                    </button>
+                    <button
+                      onClick={() => handleDeleteParticipant(participant)}
+                      disabled={deletingParticipantId === participant.id}
+                      className={`inline-flex items-center justify-center rounded-lg border p-2 text-red-500 transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                        deletingParticipantId === participant.id
+                          ? 'border-red-200 bg-red-50'
+                          : 'border-red-100 hover:border-red-300 hover:bg-red-50'
+                      }`}
+                      title="Удалить"
+                    >
+                      {deletingParticipantId === participant.id ? (
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-red-400 border-t-transparent" />
+                      ) : (
+                        <IconTrash size={16} />
+                      )}
+                    </button>
+                  </div>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- rework the admin layout shell to provide a smoother collapsible sidebar and clearer page padding on mobile and desktop
- refresh the dashboard, participants, and events screens with responsive card layouts, better spacing, and richer contextual details
- polish the public eventum landing state with a branded hero and improved empty-state messaging

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any and hook dependency warnings in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ee33b34c83289f03e3b49205bacc