### PR TITLE
feat: replace admin loading spinners with skeletons

### DIFF
--- a/frontend/src/components/admin/skeletons/EventsLoadingSkeleton.tsx
+++ b/frontend/src/components/admin/skeletons/EventsLoadingSkeleton.tsx
@@ -1,0 +1,45 @@
+const EventsLoadingSkeleton = () => (
+  <div className="space-y-3">
+    {[...Array(4)].map((_, index) => (
+      <div
+        key={index}
+        className="rounded-xl border border-gray-200 bg-white px-4 py-4 shadow-sm"
+      >
+        <div className="flex items-start justify-between gap-6">
+          <div className="flex flex-col items-start gap-2 w-24 flex-shrink-0">
+            <div className="h-3 w-20 rounded bg-gray-200 animate-pulse" />
+            <div className="h-3 w-16 rounded bg-gray-200 animate-pulse" />
+          </div>
+
+          <div className="flex-1 space-y-3">
+            <div className="h-5 w-1/2 rounded bg-gray-200 animate-pulse" />
+            <div className="flex flex-wrap gap-2">
+              {[...Array(3)].map((__, chipIndex) => (
+                <div
+                  key={chipIndex}
+                  className="h-6 w-24 rounded-full bg-gray-200 animate-pulse"
+                />
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="h-3 w-32 rounded bg-gray-200 animate-pulse" />
+              <div className="h-3 w-28 rounded bg-gray-200 animate-pulse" />
+              <div className="h-3 w-20 rounded bg-gray-200 animate-pulse" />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {[...Array(2)].map((__, buttonIndex) => (
+              <div
+                key={buttonIndex}
+                className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default EventsLoadingSkeleton;

--- a/frontend/src/components/admin/skeletons/EventumInfoSkeleton.tsx
+++ b/frontend/src/components/admin/skeletons/EventumInfoSkeleton.tsx
@@ -1,0 +1,74 @@
+const EventumInfoSkeleton = () => (
+  <div className="space-y-6">
+    <header className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="h-9 w-1/2 rounded bg-gray-200 animate-pulse" />
+        <div className="h-9 w-24 rounded-lg bg-gray-200 animate-pulse" />
+      </div>
+    </header>
+
+    <section className="space-y-3">
+      <div className="flex items-center justify-end">
+        <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse" />
+      </div>
+      <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm space-y-3">
+        {[...Array(3)].map((_, index) => (
+          <div key={index} className="h-4 w-full rounded bg-gray-200 animate-pulse" />
+        ))}
+        <div className="h-4 w-1/2 rounded bg-gray-200 animate-pulse" />
+      </div>
+    </section>
+
+    <section className="space-y-4">
+      <div className="h-6 w-32 rounded bg-gray-200 animate-pulse" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {[...Array(2)].map((_, index) => (
+          <div
+            key={index}
+            className="bg-white border border-gray-200 rounded-lg p-4"
+          >
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-lg bg-gray-200 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-3 w-20 rounded bg-gray-200 animate-pulse" />
+                <div className="h-5 w-16 rounded bg-gray-200 animate-pulse" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section className="space-y-4">
+      <div className="flex items-center gap-2">
+        <div className="h-6 w-6 rounded-full bg-gray-200 animate-pulse" />
+        <div className="h-6 w-32 rounded bg-gray-200 animate-pulse" />
+      </div>
+      <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-5 w-32 rounded bg-gray-200 animate-pulse" />
+          <div className="h-9 w-32 rounded-lg bg-gray-200 animate-pulse" />
+        </div>
+        <div className="space-y-3">
+          {[...Array(3)].map((_, index) => (
+            <div
+              key={index}
+              className="flex items-center justify-between gap-3"
+            >
+              <div className="flex items-center gap-3">
+                <div className="h-8 w-8 rounded-full bg-gray-200 animate-pulse" />
+                <div className="space-y-2">
+                  <div className="h-4 w-32 rounded bg-gray-200 animate-pulse" />
+                  <div className="h-3 w-24 rounded bg-gray-200 animate-pulse" />
+                </div>
+              </div>
+              <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  </div>
+);
+
+export default EventumInfoSkeleton;

--- a/frontend/src/components/admin/skeletons/GroupsLoadingSkeleton.tsx
+++ b/frontend/src/components/admin/skeletons/GroupsLoadingSkeleton.tsx
@@ -1,0 +1,47 @@
+const GroupsLoadingSkeleton = () => (
+  <div
+    className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+    style={{ gridAutoRows: 'min-content', alignItems: 'start' as const }}
+  >
+    {[...Array(6)].map((_, index) => (
+      <div
+        key={index}
+        className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm"
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div className="space-y-2 w-full">
+            <div className="h-5 w-2/3 rounded bg-gray-200 animate-pulse" />
+            <div className="flex flex-wrap gap-2">
+              {[...Array(2)].map((__, tagIndex) => (
+                <div
+                  key={tagIndex}
+                  className="h-5 w-20 rounded-full bg-gray-200 animate-pulse"
+                />
+              ))}
+            </div>
+          </div>
+          <div className="ml-4 h-8 w-8 rounded-lg bg-gray-200 animate-pulse" />
+        </div>
+
+        <div className="space-y-2">
+          {[...Array(3)].map((__, participantIndex) => (
+            <div
+              key={participantIndex}
+              className="flex items-center justify-between"
+            >
+              <div className="h-3 w-32 rounded bg-gray-200 animate-pulse" />
+              <div className="h-6 w-6 rounded bg-gray-200 animate-pulse" />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex gap-2">
+          <div className="h-8 flex-1 rounded-lg bg-gray-200 animate-pulse" />
+          <div className="h-8 flex-1 rounded-lg bg-gray-200 animate-pulse" />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default GroupsLoadingSkeleton;

--- a/frontend/src/components/admin/skeletons/LocationsLoadingSkeleton.tsx
+++ b/frontend/src/components/admin/skeletons/LocationsLoadingSkeleton.tsx
@@ -1,0 +1,56 @@
+const LocationsLoadingSkeleton = () => (
+  <div className="space-y-4">
+    <div className="flex items-center justify-between mb-4">
+      <div className="h-5 w-40 rounded bg-gray-200 animate-pulse" />
+      <div className="h-9 w-48 rounded-lg bg-gray-200 animate-pulse" />
+    </div>
+
+    {[...Array(3)].map((_, index) => (
+      <div
+        key={index}
+        className="bg-white border border-gray-200 rounded-lg p-4"
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-4 w-4 rounded-full bg-gray-200 animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-1/3 rounded bg-gray-200 animate-pulse" />
+            <div className="h-3 w-1/4 rounded bg-gray-200 animate-pulse" />
+          </div>
+          <div className="flex items-center gap-2">
+            {[...Array(3)].map((__, buttonIndex) => (
+              <div
+                key={buttonIndex}
+                className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="ml-6 mt-4 space-y-2">
+          {[...Array(2)].map((__, childIndex) => (
+            <div
+              key={childIndex}
+              className="flex items-center gap-3"
+            >
+              <div className="h-4 w-4 rounded bg-gray-200 animate-pulse" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 w-1/3 rounded bg-gray-200 animate-pulse" />
+                <div className="h-2 w-1/4 rounded bg-gray-200 animate-pulse" />
+              </div>
+              <div className="flex items-center gap-2">
+                {[...Array(2)].map((___, childButtonIndex) => (
+                  <div
+                    key={childButtonIndex}
+                    className="h-6 w-6 rounded bg-gray-200 animate-pulse"
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default LocationsLoadingSkeleton;

--- a/frontend/src/components/admin/skeletons/TagsLoadingSkeleton.tsx
+++ b/frontend/src/components/admin/skeletons/TagsLoadingSkeleton.tsx
@@ -1,0 +1,32 @@
+const TagsLoadingSkeleton = () => (
+  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {[...Array(6)].map((_, index) => (
+      <div
+        key={index}
+        className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm"
+      >
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="space-y-2 flex-1">
+            <div className="h-5 w-2/3 rounded bg-gray-200 animate-pulse" />
+            <div className="h-3 w-full rounded bg-gray-200 animate-pulse" />
+          </div>
+          <div className="h-8 w-8 rounded-lg bg-gray-200 animate-pulse" />
+        </div>
+
+        <div className="space-y-2">
+          {[...Array(3)].map((__, itemIndex) => (
+            <div
+              key={itemIndex}
+              className="flex items-center justify-between"
+            >
+              <div className="h-3 w-36 rounded bg-gray-200 animate-pulse" />
+              <div className="h-6 w-6 rounded bg-gray-200 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default TagsLoadingSkeleton;

--- a/frontend/src/pages/admin/EventTagsPage.tsx
+++ b/frontend/src/pages/admin/EventTagsPage.tsx
@@ -7,6 +7,7 @@ import { eventTagApi } from '../../api/eventTag';
 import type { EventTag, Event } from '../../types';
 import { IconPencil, IconX, IconPlus, IconInformationCircle, IconTrash } from '../../components/icons';
 import { useEventumSlug } from '../../hooks/useEventumSlug';
+import TagsLoadingSkeleton from '../../components/admin/skeletons/TagsLoadingSkeleton';
 
 const AdminEventTagsPage = () => {
   const eventumSlug = useEventumSlug();
@@ -251,12 +252,6 @@ const AdminEventTagsPage = () => {
     }
   };
 
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
   const toggleTagExpansion = (tagId: number) => {
     setExpandedTags(prev => {
       const newSet = new Set(prev);
@@ -302,7 +297,7 @@ const AdminEventTagsPage = () => {
       />
 
       {isLoading ? (
-        <LoadingSpinner />
+        <TagsLoadingSkeleton />
       ) : (
         <div className="columns-1 sm:columns-2 lg:columns-3 gap-4">
           {/* Карточка для добавления нового тега */}

--- a/frontend/src/pages/admin/EventsPage.tsx
+++ b/frontend/src/pages/admin/EventsPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../components/icons";
 import EventEditModal from "../../components/event/EventEditModal";
 import { useEventumSlug } from "../../hooks/useEventumSlug";
+import EventsLoadingSkeleton from "../../components/admin/skeletons/EventsLoadingSkeleton";
 
 interface EventWithTags extends Event {
   tags_data: EventTag[];
@@ -228,13 +229,6 @@ const AdminEventsPage = () => {
     }
   };
 
-
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
   return (
     <div className="space-y-6">
       <header className="space-y-2">
@@ -305,7 +299,7 @@ const AdminEventsPage = () => {
 
       {/* Список мероприятий */}
       {isLoading ? (
-        <LoadingSpinner />
+        <EventsLoadingSkeleton />
       ) : (
         <div className="space-y-3">
           {filteredEvents.map((event) => {

--- a/frontend/src/pages/admin/EventumInfoPage.tsx
+++ b/frontend/src/pages/admin/EventumInfoPage.tsx
@@ -13,6 +13,7 @@ import {
   IconSettings,
   IconX
 } from "../../components/icons";
+import EventumInfoSkeleton from "../../components/admin/skeletons/EventumInfoSkeleton";
 
 const EventumInfoPage = () => {
   const eventumSlug = useEventumSlug();
@@ -173,14 +174,8 @@ const EventumInfoPage = () => {
     }
   };
 
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
   if (isLoading) {
-    return <LoadingSpinner />;
+    return <EventumInfoSkeleton />;
   }
 
   if (!eventum) {

--- a/frontend/src/pages/admin/GroupTagsPage.tsx
+++ b/frontend/src/pages/admin/GroupTagsPage.tsx
@@ -7,6 +7,7 @@ import { groupTagApi } from '../../api/groupTag';
 import type { GroupTag, ParticipantGroup } from '../../types';
 import { IconPencil, IconX, IconPlus, IconInformationCircle, IconTrash } from '../../components/icons';
 import { useEventumSlug } from '../../hooks/useEventumSlug';
+import TagsLoadingSkeleton from '../../components/admin/skeletons/TagsLoadingSkeleton';
 
 const AdminGroupTagsPage = () => {
   const eventumSlug = useEventumSlug();
@@ -242,12 +243,6 @@ const AdminGroupTagsPage = () => {
     }
   };
 
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
   const toggleTagExpansion = (tagId: number) => {
     setExpandedTags(prev => {
       const newSet = new Set(prev);
@@ -293,7 +288,7 @@ const AdminGroupTagsPage = () => {
       />
 
       {isLoading ? (
-        <LoadingSpinner />
+        <TagsLoadingSkeleton />
       ) : (
         <div className="columns-1 sm:columns-2 lg:columns-3 gap-4">
           {/* Карточка для добавления нового тега */}

--- a/frontend/src/pages/admin/GroupsPage.tsx
+++ b/frontend/src/pages/admin/GroupsPage.tsx
@@ -8,6 +8,7 @@ import {
 import type { ParticipantGroup, Participant } from '../../types';
 import { IconPencil, IconX, IconPlus, IconInformationCircle, IconTrash } from '../../components/icons';
 import { useEventumSlug } from '../../hooks/useEventumSlug';
+import GroupsLoadingSkeleton from '../../components/admin/skeletons/GroupsLoadingSkeleton';
 
 const AdminGroupsPage = () => {
   const eventumSlug = useEventumSlug();
@@ -166,13 +167,6 @@ const AdminGroupsPage = () => {
     }
   };
 
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
-
   const toggleGroupExpansion = (groupId: number) => {
     setExpandedGroups(prev => {
       const newSet = new Set(prev);
@@ -184,7 +178,6 @@ const AdminGroupsPage = () => {
       return newSet;
     });
   };
-
 
   return (
     <div className="space-y-6">
@@ -211,7 +204,7 @@ const AdminGroupsPage = () => {
       />
 
       {isLoading ? (
-        <LoadingSpinner />
+        <GroupsLoadingSkeleton />
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" style={{ gridAutoRows: 'min-content', alignItems: 'start' }}>
           {/* Карточка для добавления новой группы */}

--- a/frontend/src/pages/admin/LocationsPage.tsx
+++ b/frontend/src/pages/admin/LocationsPage.tsx
@@ -10,6 +10,7 @@ import { LocationForm } from '../../components/location/LocationForm';
 import { IconInformationCircle } from '../../components/icons';
 import type { Location, CreateLocationData } from '../../types';
 import { useEventumSlug } from '../../hooks/useEventumSlug';
+import LocationsLoadingSkeleton from '../../components/admin/skeletons/LocationsLoadingSkeleton';
 
 const LocationsPage = () => {
   const eventumSlug = useEventumSlug();
@@ -173,14 +174,8 @@ const LocationsPage = () => {
     }
   };
 
-  const LoadingSpinner = () => (
-    <div className="flex items-center justify-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-    </div>
-  );
-
   if (isLoading) {
-    return <LoadingSpinner />;
+    return <LocationsLoadingSkeleton />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- add dedicated skeleton components for admin events, groups, tags, locations, and eventum overview screens
- switch admin pages to use the new skeletons instead of spinner loaders during data fetches

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da08e6a5988328ae73fc4058b1063a