### PR TITLE
Fix text contrast on iOS by forcing light color scheme

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,8 +2,10 @@
 @import "./placeholder-fix.css";
 
 :root {
+  /* Принудительно используем светлую цветовую схему, потому что интерфейс не поддерживает dark mode */
+  color-scheme: light;
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #111827;
 }
 
 @theme inline {
@@ -11,13 +13,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {


### PR DESCRIPTION
## Summary
- force the frontend to always use the light color palette because the UI does not support dark mode
- set the color scheme hint to light so browsers stop tinting text on selects and headings in dark system mode

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbfb143c5c83289eeb824b7751a087