### PR TITLE
Fix auth requests slug handling on subdomains

### DIFF
--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -3,7 +3,6 @@
  */
 import axios, { type AxiosResponse, type AxiosError, type AxiosRequestConfig } from 'axios';
 import { getCookie, setCookie, deleteCookie, getMerupCookieOptions } from '../utils/cookies';
-import { getSubdomainSlug } from '../utils/eventumSlug';
 
 // Определяем базовый URL API
 const getApiBaseUrl = (): string => {
@@ -141,17 +140,11 @@ apiClient.interceptors.response.use(
 // Функция для создания URL с учетом поддоменов
 export const createApiUrl = (path: string, eventumSlug?: string): string => {
   const baseUrl = getApiBaseUrl();
-  const subdomainSlug = getSubdomainSlug();
-  
-  // Определяем slug: либо переданный явно, либо из поддомена
-  const slug = eventumSlug || subdomainSlug;
-  
-  // Если есть slug, всегда добавляем его в путь
-  if (slug) {
-    return `${baseUrl}/eventums/${slug}${path}`;
+
+  if (eventumSlug) {
+    return `${baseUrl}/eventums/${eventumSlug}${path}`;
   }
-  
-  // Если нет slug, возвращаем путь без него (для общих endpoints)
+
   return `${baseUrl}${path}`;
 };
 

--- a/frontend/src/api/eventumApi.ts
+++ b/frontend/src/api/eventumApi.ts
@@ -14,8 +14,14 @@ import type {
 } from '../types';
 
 // Базовая функция для определения eventumSlug
-const getEventumSlugForRequest = (providedSlug?: string): string | undefined => {
-  return getSubdomainSlug() || providedSlug;
+const getEventumSlugForRequest = (providedSlug?: string): string => {
+  const slug = getSubdomainSlug() || providedSlug;
+
+  if (!slug) {
+    throw new Error('Eventum slug is required for eventum-scoped API requests');
+  }
+
+  return slug;
 };
 
 // ============= EVENTUM API =============


### PR DESCRIPTION
## Summary
- stop automatically prefixing all API calls with the subdomain slug so global auth endpoints remain accessible
- raise an error when event-scoped API helpers are invoked without a slug to ensure slugs are always provided explicitly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2f3a682883289f780270a5874310